### PR TITLE
Client data fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "debug": "node --inspect-brk node_modules/@glas/test/gtest.js lib",
         "watch:build": "yarn copy && isc src lib -w",
         "watch:test": "nodemon --delay 100ms -w lib -x gtest lib",
+        "watch:debug": "nodemon --inspect-brk node_modules/@glas/test/gtest.js lib",
         "watch": "run-p watch:*"
     },
     "dependencies": {
@@ -26,7 +27,7 @@
         "react-firebaseui": "^4.1.0"
     },
     "devDependencies": {
-        "@glas/test": "^1.0.3",
+        "@glas/test": "^1.0.4",
         "jsdom": "^16.4.0",
         "npm-run-all": "^4.1.5"
     }

--- a/src/data/Cache.is
+++ b/src/data/Cache.is
@@ -1,0 +1,4 @@
+
+meta Cache: Function = (record) -> null
+
+export default Cache

--- a/src/data/stores/FireStore.is
+++ b/src/data/stores/FireStore.is
@@ -119,6 +119,17 @@ export default class FireStore extends MemoryStore
                                 keyValues.push([key, value])
                     // save keys as result of query.
                     this._hasResults.add(key.toString())
+
+                    // if keyValues.length > 0
+                    //     console.log("")
+                    //     console.log("=Snapshot:============================")
+                    //     for [key, value] in keyValues
+                    //         console.log()
+                    //             JSON.stringify()
+                    //                 value, null, 2
+                    //     console.log("======================================")
+                    //     console.log("")
+                    
                     super._setValue(key, keyValues)
         else
             let docRef = this.db.doc(key.path)

--- a/src/data/stores/FireStore.is
+++ b/src/data/stores/FireStore.is
@@ -2,6 +2,7 @@ import ..Key
     IdentityKey
     QueryKey
 import ..Index
+import ..Cache
 import .MemoryStore
 import ..Serializer
 import ..Namespace
@@ -29,11 +30,19 @@ export function getIndexedValues(record, values = {}, prefix = "") ->
     
     return values
 
+export function getCachedValues(record) ->
+    return {}
+        for [name, property] in record.properties
+            let cacheFn = property[Cache.symbol]
+            if cacheFn
+                [name]: cacheFn(record)
+
 let getSerializer = common.memoize(ns -> new Serializer(ns))
 
 function serialize(record: Record, namespace: Namespace) ->
+    let cachedValues = getCachedValues(record)
     //  remove the type
-    let values = Object.assign({}, record)
+    let values = Object.assign({}, record, cachedValues)
     //  remove the key
     delete values.key
     return getSerializer(namespace).stringify(values)

--- a/src/data/stores/FireStore.is
+++ b/src/data/stores/FireStore.is
@@ -119,6 +119,15 @@ export default class FireStore extends MemoryStore
                                 keyValues.push([key, value])
                     // save keys as result of query.
                     this._hasResults.add(key.toString())
+
+                    // if key.type.name == "Location"
+                    //     console.log()
+                    //         key.toString()
+                    //         JSON.stringify()
+                    //             keyValues.map()
+                    //                 kv -> kv[1]
+                    //             null, 2
+                    
                     super._setValue(key, keyValues)
         else
             let docRef = this.db.doc(key.path)
@@ -142,9 +151,9 @@ export default class FireStore extends MemoryStore
                         if key.type isnt Null && value.constructor != key.type
                             value = new key.type(value)
 
-                    let doc = toDocumentValues(value, this.namespace)
                     let docRef = this.db.doc(key.path)
                     if value isnt Null
+                        let doc = toDocumentValues(value, this.namespace)
                         docRef.set(doc, { merge: true })
                         .then()
                             =>

--- a/src/data/stores/FireStore.is
+++ b/src/data/stores/FireStore.is
@@ -119,15 +119,6 @@ export default class FireStore extends MemoryStore
                                 keyValues.push([key, value])
                     // save keys as result of query.
                     this._hasResults.add(key.toString())
-
-                    // if key.type.name == "Location"
-                    //     console.log()
-                    //         key.toString()
-                    //         JSON.stringify()
-                    //             keyValues.map()
-                    //                 kv -> kv[1]
-                    //             null, 2
-                    
                     super._setValue(key, keyValues)
         else
             let docRef = this.db.doc(key.path)

--- a/src/data/stores/MemoryStore.is
+++ b/src/data/stores/MemoryStore.is
@@ -114,15 +114,19 @@ export default class MemoryStore extends Store
         let currentValue = this.peek(key)
         if currentValue == value
             return false
+            
         if value is Null
             this.values.delete(key.toString())
         else
             this.values.set(key.toString(), [key, value])
 
         if value is Array
+            let table = this.tables.get(key.toString())
+            if table
+                table.updateQuery(key, value)
             await this._updateValues(notifyQueue, ...value)
-        // else if value isnt Null
-        await this._updateValues(notifyQueue, [key, value])
+        else
+            await this._updateValues(notifyQueue, [key, value])
 
         notifyQueue.set(key.toString(), value)
         for [key, value] in notifyQueue

--- a/src/data/stores/MemoryStore.is
+++ b/src/data/stores/MemoryStore.is
@@ -98,14 +98,14 @@ export default class MemoryStore extends Store
     async _updateValues(notifyQueue, ...keyValues) ->
         let updateTables = new Set()
         for [key, value] in keyValues
-            if value isnt Null
-                if key is IdentityKey
-                    if key.type isnt Null && value isnt Null
-                        if value isnt key.type
-                            throw new Error(value + " isnt type " + (key.type.name ?? key.type))
-                    for table in this.tables.values()
-                        if table.update(key, value)
-                            updateTables.add(table)
+            // if value isnt Null
+            if key is IdentityKey
+                if key.type isnt Null && value isnt Null
+                    if value isnt key.type
+                        throw new Error(value + " isnt type " + (key.type.name ?? key.type))
+                for table in this.tables.values()
+                    if table.update(key, value)
+                        updateTables.add(table)
         for table in updateTables
             notifyQueue.set(table.key.toString(), table.getValues(this))
 
@@ -121,8 +121,8 @@ export default class MemoryStore extends Store
 
         if value is Array
             await this._updateValues(notifyQueue, ...value)
-        else if value isnt Null
-            await this._updateValues(notifyQueue, [key, value])
+        // else if value isnt Null
+        await this._updateValues(notifyQueue, [key, value])
 
         notifyQueue.set(key.toString(), value)
         for [key, value] in notifyQueue

--- a/src/data/stores/MemoryStore.is
+++ b/src/data/stores/MemoryStore.is
@@ -71,9 +71,12 @@ export default class MemoryStore extends Store
 
     peek(key: Key) ->
         if key is IdentityKey
-            let value = this.values.get(key.toString())
-            return value?[1]
+            return this.peekRaw(key)
         return this._getTable(key).getValues(this)
+    
+    peekRaw(key: Key) ->
+        let value = this.values.get(key.toString())
+        return value?[1]
 
     async patch(key: IdentityKey, value) ->
         value = clonePatch(await this.get(key), value)

--- a/src/data/stores/Table.is
+++ b/src/data/stores/Table.is
@@ -42,6 +42,17 @@ export default class Table
                 this.values.sort(createSortCompareFunction(this.key.query))
         return this.values
 
+    updateQuery(key: QueryKey, keyValues) ->
+        if keyValues.length != this.keys.size
+            this.invalidateValues()
+            return true
+        else
+            for [key, value] in keyValues
+                if !this.keys.has(key)
+                    this.invalidateValues()
+                    return true
+        return false
+
     update(key: IdentityKey, value): Boolean ->
         if value isnt Null
             if isPossibleMatch(this.key, key) && this.filter(value)
@@ -51,7 +62,7 @@ export default class Table
                     return true
             else
                 value = null
-
+                
         if value is Null && this.keys.has(key.toString())
             this.invalidateValues()
             this.keys.delete(key.toString())

--- a/src/data/stores/Table.is
+++ b/src/data/stores/Table.is
@@ -25,17 +25,28 @@ export default class Table
         this.values = null
 
     getValues(store: Store) ->
+        // if window.__dbg
+        //     debugger
         if this.values is Null
             this.values = []
-            for key in this.keys.values()
-                let value = store.peek(key)
-                if value isnt Null
+            let visited = new Set()
+            let rawValues = store.peekRaw(this.key)
+            if rawValues
+                for [key, value] in rawValues
+                    visited.add(key.toString())
                     this.values.push([key, value])
+            for key in this.keys.values()
+                if !visited.has(key.toString())
+                    let value = store.peek(key)
+                    if value isnt Null
+                        this.values.push([key, value])
             if this.key.query.sort isnt Null && this.key.query.sort.length > 0
                 this.values.sort(createSortCompareFunction(this.key.query))
         return this.values
 
     update(key: IdentityKey, value): Boolean ->
+        if key.type.name == "Location"
+            console.log({key, value})
         if value isnt Null
             if isPossibleMatch(this.key, key) && this.filter(value)
                 if !this.keys.has(key.toString())

--- a/src/data/stores/Table.is
+++ b/src/data/stores/Table.is
@@ -25,8 +25,6 @@ export default class Table
         this.values = null
 
     getValues(store: Store) ->
-        // if window.__dbg
-        //     debugger
         if this.values is Null
             this.values = []
             let visited = new Set()
@@ -45,8 +43,6 @@ export default class Table
         return this.values
 
     update(key: IdentityKey, value): Boolean ->
-        if key.type.name == "Location"
-            console.log({key, value})
         if value isnt Null
             if isPossibleMatch(this.key, key) && this.filter(value)
                 if !this.keys.has(key.toString())

--- a/src/data/stores/test/MemoryStore.test.is
+++ b/src/data/stores/test/MemoryStore.test.is
@@ -45,6 +45,29 @@ assert.doesNotReject()
 data class Person extends Model
     name: String
 
+// Verify that watching identical keys no longer gives incomplete results.
+do async ->
+    try
+        var store = new MemoryStore()
+        var key = Key.create(Integer, {})
+        var events = []
+        var expectedEvents = []
+            "A "
+            "A Integer/foo,11"
+            "A Integer/foo,11"
+            "B Integer/foo,11"
+        store.watch()
+            key
+            newValue -> events.push("A " + newValue.toString())
+        await store._setValue(key, [[Key.create(Integer, "foo"), 11]])
+        store.watch()
+            key
+            newValue -> events.push("B " + newValue.toString())
+        assert.equal()
+            JSON.stringify(events)
+            JSON.stringify(expectedEvents)
+    catch e
+        console.error(e)
 
 // //  Where Query Peeking
 // store = new MemoryStore()

--- a/src/graphics/math/Vector2.is
+++ b/src/graphics/math/Vector2.is
@@ -46,12 +46,12 @@ export default data struct Vector2
         return new Vector2(this.x * invLength, this.y * invLength)
     translate(v: Vector2) -> this.add(v)
     transform(m: Matrix4) ->
-        let { x, y, z } = this
-        let w = (m.m03 * x + m.m13 * y + m.m23 * z + m.m33) || 1.0
+        let { x, y } = this
+        let w = (m.m03 * x + m.m13 * y + m.m33) || 1.0
         return
             new Vector2()
-                (m.m00 * x + m.m10 * y + m.m20 * z + m.m30) / w
-                (m.m01 * x + m.m11 * y + m.m21 * z + m.m31) / w
+                (m.m00 * x + m.m10 * y + m.m30) / w
+                (m.m01 * x + m.m11 * y + m.m31) / w
     writeTo(array, index: F32) ->
         array[index + 0] = this.x
         array[index + 1] = this.y

--- a/src/utility/guid.is
+++ b/src/utility/guid.is
@@ -5,12 +5,10 @@ let guid = () ->
     let array = new Array(20)
     window.crypto.getRandomValues(buffer)
     for i in 0 .. buffer.length
-        let string = buffer[i].toString(16)
-        if string.length < 2
-            array.push("0")
-        array.push(string)
+        let string = buffer[i].toString(16).padStart(2, "0")
         if i == 4 || i == 6 || i == 8 || i == 10
             array.push("-")
+        array.push(string)
     return array.join("")
 
 export let format = /^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$/i

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,11 @@
   resolved "https://registry.yarnpkg.com/@glas/test/-/test-1.0.3.tgz#f2d1780aed3bb42b34de27920fee27f7f86d02df"
   integrity sha512-SJqhXBwN48D60njrq544fxowiqrFivQ9FfgeHYyCNv99p72KE19kFDXY1aqsAY7MN9hnBS3P+0/3VBqhVw92Bw==
 
+"@glas/test@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@glas/test/-/test-1.0.4.tgz#de06433f506131abb2d3b4673ba8d99fc6a57f8d"
+  integrity sha512-kw/8dHN0yFlr3El6/TfXi1uV5rt1KD5TZkkr0IWf40eFUk1ka+1PljQzJkU8YXKGoUqQp1i60kbOmpdrOGHCDg==
+
 "@glas/traverse@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@glas/traverse/-/traverse-1.0.6.tgz#a3b8d8e40f4f8a2c66f9c5f39303d55335823e6c"


### PR DESCRIPTION
These are fixes for issues with the client data layer. 

### Observing a query already in use gives incomplete results.
`Table.getValues` would only look at top level entries in `MemoryStore.values` via `MemoryStore.peek`. This resulted in new observers of queries already in use only seeing entities that are at the top level in `MemoryStore.values`.

### Error on deletions.
`FireStore._setValue` was attempting to convert a value to a document before checking if it was null.

### Deletions don't propagate through to MemoryStore's Tables.
I removed `is Null` checks in `MemoryStore._setValue` and `MemoryStore._updateValues` to allow deletions through to `Table.update`.